### PR TITLE
chore: add typescript-eslint to renovate automerge list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -23,7 +23,8 @@
         "knip",
         "changesets/action",
         "@vitest/eslint-plugin",
-        "eslint-import-resolver-typescript"
+        "eslint-import-resolver-typescript",
+        "typescript-eslint"
       ],
       "automerge": true
     },


### PR DESCRIPTION
## Summary
- Add typescript-eslint to the Renovate automerge configuration

## Rationale
The typescript-eslint package:
- Follows semantic versioning
- Is a development dependency (no runtime impact)
- Changes are validated by our CI pipeline (linters and builds)
- Similar to other tools already in the automerge list

This will allow minor and patch updates to be merged automatically after CI passes.