### PR TITLE
feat: implement lefthook for pre-commit linting

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -12,5 +12,6 @@
       "entry": ["src/main.tsx"],
       "project": ["src/**/*.{ts,tsx}"]
     }
-  }
+  },
+  "lefthook": false
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+pre-commit:
+  commands:
+    lint:
+      run: pnpm lint
+      fail_text: "Linting failed. Please fix the issues and try again."
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "22.16.0",
     "eslint": "9.19.0",
     "knip": "5.61.3",
+    "lefthook": "1.12.0",
     "scaffdog": "4.1.0",
     "syncpack": "13.0.4",
     "typescript": "5.8.3"
@@ -31,6 +32,7 @@
     "lint:example": "pnpm --filter vite-project lint && pnpm --filter vite-project build",
     "lint:knip": "knip",
     "lint:syncpack": "syncpack lint",
+    "prepare": "lefthook install",
     "release": "changeset publish"
   },
   "packageManager": "pnpm@10.12.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       knip:
         specifier: 5.61.3
         version: 5.61.3(@types/node@22.16.0)(typescript@5.8.3)
+      lefthook:
+        specifier: 1.12.0
+        version: 1.12.0
       scaffdog:
         specifier: 4.1.0
         version: 4.1.0
@@ -2469,6 +2472,60 @@ packages:
   latest-version@9.0.0:
     resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
     engines: {node: '>=18'}
+
+  lefthook-darwin-arm64@1.12.0:
+    resolution: {integrity: sha512-XMwneWj+Ux/6lI+T8ZmXwPkPS9b2n9DgMcjR4kNDTzPClBTNjKngQkh/SOzOKV/w//fkkQCdfCRMvV9f9FLS3A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.12.0:
+    resolution: {integrity: sha512-juGzUr41z8y8zhLhZhvqN9WeqHPoovFTymGg3gmj0bkrYj2V+dSRtl+nbbz5EZTeK2T32BvrYINQJjV9rmnjwg==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.12.0:
+    resolution: {integrity: sha512-2YUGdslUhzjpHLmXeOX8xhuZkYokotIMjnhN198Vly0aC+kq6ognRnUjBHOSjlIf1i9gAU7sV81yEuofNYv8Mw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.12.0:
+    resolution: {integrity: sha512-zzPu+6oD4oEh+oS0ayChlb+Y6i5momSM8gBcJKNmuze0xdFt3O4Z104ogXznRGh8bFgrPmtJgeLpwemfG/5fKg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.12.0:
+    resolution: {integrity: sha512-oMFkBZS7ax/upTFXfnSrqkiiwPtn1rp6vIEQhjWTxQnNcjd8dbZSlVUcpn0yolSpVAnPSKN+2pbLZEonD24YEw==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.12.0:
+    resolution: {integrity: sha512-IKPJcu14FjvefaXC4VZ9NSxZicVoTGZ86OlqiYvT+1hov850YEyusIEo/J8fEzZzQ2F16tQ24iqzrOLtXpp1gQ==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.12.0:
+    resolution: {integrity: sha512-pZWid2jTvBgKEHJEKr6bAR9dXXTpA+2XKtxRFSLoI0KXDI9BH8KxH50zO6Y83siB96YygHlsjWbSsObIYC8Tgw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.12.0:
+    resolution: {integrity: sha512-gHHqgcuJHzWThnhUUFxk8lm2pSL0z/xGHgZakmBct5vzItfEmXFmlnKHFbWbam4fvNIWKGFKAVCWH3O7x0IQVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.12.0:
+    resolution: {integrity: sha512-SXbD5zCCpMSorgr14h4IzgFfBkxJsvso15VTFy1YrIAaM3jhrjlinm/Zk5gBZi82D8J+JbAlbhWC4Z93ombgoA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.12.0:
+    resolution: {integrity: sha512-cUOpmq8qJMhrOTqAXklsSbSaIxABVPBcENOD84N/pyqQpCdR3LAxIcq5cHLLap6ek8zPYwvFeBe1hVQC/X/xvQ==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.12.0:
+    resolution: {integrity: sha512-+lJSdsNcKzxv4TcIcXrd21lBXI7wrVXZ080wiJzz4sHz52KyKVPfALDPMm7+VWBtATpnCtHQe2ZPQwiBmy6VRw==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -5809,6 +5866,49 @@ snapshots:
   latest-version@9.0.0:
     dependencies:
       package-json: 10.0.1
+
+  lefthook-darwin-arm64@1.12.0:
+    optional: true
+
+  lefthook-darwin-x64@1.12.0:
+    optional: true
+
+  lefthook-freebsd-arm64@1.12.0:
+    optional: true
+
+  lefthook-freebsd-x64@1.12.0:
+    optional: true
+
+  lefthook-linux-arm64@1.12.0:
+    optional: true
+
+  lefthook-linux-x64@1.12.0:
+    optional: true
+
+  lefthook-openbsd-arm64@1.12.0:
+    optional: true
+
+  lefthook-openbsd-x64@1.12.0:
+    optional: true
+
+  lefthook-windows-arm64@1.12.0:
+    optional: true
+
+  lefthook-windows-x64@1.12.0:
+    optional: true
+
+  lefthook@1.12.0:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.12.0
+      lefthook-darwin-x64: 1.12.0
+      lefthook-freebsd-arm64: 1.12.0
+      lefthook-freebsd-x64: 1.12.0
+      lefthook-linux-arm64: 1.12.0
+      lefthook-linux-x64: 1.12.0
+      lefthook-openbsd-arm64: 1.12.0
+      lefthook-openbsd-x64: 1.12.0
+      lefthook-windows-arm64: 1.12.0
+      lefthook-windows-x64: 1.12.0
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Implement lefthook as a git hook manager to run linting checks on pre-commit
- Ensure code quality by running linters before commits
- Prevent commits that would fail CI linting checks
- Improve developer experience with fast, local feedback

## Changes
- Install lefthook as a dev dependency
- Configure lefthook.yml with pre-commit hooks for `pnpm lint`
- Add prepare script to automatically install hooks on `pnpm install`
- Update knip configuration to properly handle lefthook

## Test plan
- [x] Lefthook installation and setup
- [x] Pre-commit hook runs successfully
- [x] Linting failures prevent commits
- [x] All existing linters pass
- [x] Build succeeds

Closes #176

🤖 Generated with [Claude Code](https://claude.ai/code)