### PR TITLE
feat: Setup TypeScript configuration for CLI project (#175)

### DIFF
--- a/typescript/packages/configs/tsconfig.json
+++ b/typescript/packages/configs/tsconfig.json
@@ -1,14 +1,11 @@
 {
+  "extends": "./tsconfig/base.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
     "lib": ["ES2022"],
     "outDir": "./bin",
     "rootDir": "./src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary
- Modified `typescript/packages/configs/tsconfig.json` to extend the shared `base.json` configuration
- Removed duplicate strict compiler options that are already defined in the base configuration  
- Kept CLI-specific options like `outDir`, `rootDir`, `declaration`, etc.

## Test plan
- [x] TypeScript compilation works without errors (`pnpm build`)
- [x] All linters pass (`pnpm lint` and `pnpm fmt`)
- [x] Configuration properly extends shared base settings

Fixes #175

🤖 Generated with [Claude Code](https://claude.ai/code)