### PR TITLE
fix: change test script to use 'vitest run' instead of 'vitest'

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:syncpack": "syncpack lint",
     "prepare": "lefthook install",
     "release": "changeset publish",
-    "test": "vitest",
+    "test": "vitest run",
     "test:coverage": "vitest --coverage",
     "test:ui": "vitest --ui"
   },


### PR DESCRIPTION
## Summary
Changed the `pnpm test` script from `vitest` to `vitest run` to run tests once and exit instead of running in watch mode.

## Changes
- Updated `package.json` line 40: `"test": "vitest run"`
- This prevents tests from running in watch mode by default
- Improves integration with automated tools and CI/CD pipelines
- `pnpm test:ui` still available for interactive testing

## Impact
- Tests will no longer run in watch mode by default
- Better integration with automated tools and CI/CD pipelines
- Claude Code can now properly detect test completion

Fixes #196

Generated with [Claude Code](https://claude.ai/code)