### PR TITLE
ci: enable allowed_tools for Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,7 +50,7 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          allowed_tools: "Bash(pnpm install),Bash(pnpm build),Bash(pnpm test*),Bash(pnpm lint*),Bash(pnpm fmt*)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,7 +50,7 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
-          allowed_tools: "Bash(pnpm install),Bash(pnpm build),Bash(pnpm test*),Bash(pnpm lint*),Bash(pnpm fmt*)"
+          allowed_tools: "Bash(pnpm install),Bash(pnpm build),Bash(pnpm test:*),Bash(pnpm lint:*),Bash(pnpm fmt:*)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |


### PR DESCRIPTION
## Summary
- Configure Claude Code action to allow essential pnpm commands
- Enable `pnpm install`, `pnpm build`, `pnpm test*`, `pnpm lint*`, `pnpm fmt*`

## Test plan
- [x] All tests pass (`pnpm test`)
- [x] All linters pass (`pnpm lint`) 
- [x] Build succeeds (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.ai/code)