### PR TITLE
ci: add reusable unslop workflow

### DIFF
--- a/.github/workflows/_unslop.yml
+++ b/.github/workflows/_unslop.yml
@@ -1,0 +1,91 @@
+# @usage
+#
+# jobs:
+#   unslop:
+#     if: github.event_name == 'pull_request'
+#     uses: MH4GF/shared-config/.github/workflows/_unslop.yml@main
+#     with:
+#       config: .textlintrc.json
+#
+on:
+  workflow_call:
+    inputs:
+      config:
+        description: textlint config path (relative to the caller repo root)
+        type: string
+        default: .textlintrc.json
+
+jobs:
+  unslop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Resolve unslop revision
+        id: unslop-rev
+        run: |
+          sha=$(git ls-remote https://github.com/MH4GF/unslop HEAD | cut -f1)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Cache unslop binary
+        id: cache-unslop
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cargo/bin/unslop
+          key: unslop-${{ runner.os }}-${{ steps.unslop-rev.outputs.sha }}
+
+      - name: Install unslop
+        if: steps.cache-unslop.outputs.cache-hit != 'true'
+        run: cargo install --git https://github.com/MH4GF/unslop --rev ${{ steps.unslop-rev.outputs.sha }} --locked
+
+      - name: Collect changed Markdown files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD -- '*.md' '*.mdx' || true)
+          if [ -z "$files" ]; then
+            echo "No changed Markdown files."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ja_files=""
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            [ -r "$file" ] || continue
+            if perl -CSD -0777 -ne 'exit(/\p{Hiragana}|\p{Katakana}|\p{Han}/ ? 0 : 1)' "$file" 2>/dev/null; then
+              ja_files="${ja_files}${file}"$'\n'
+            fi
+          done <<< "$files"
+          if [ -z "$ja_files" ]; then
+            echo "No Japanese Markdown files changed."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "files<<__EOF__"
+            printf '%s' "$ja_files"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run unslop on changed files
+        if: steps.changed.outputs.files != ''
+        env:
+          FILES: ${{ steps.changed.outputs.files }}
+          CONFIG: ${{ inputs.config }}
+        run: |
+          set -uo pipefail
+          rc=0
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            echo "::group::unslop $file"
+            if ! unslop -c "$CONFIG" --no-color "$file"; then
+              rc=1
+            fi
+            echo "::endgroup::"
+          done <<< "$FILES"
+          exit "$rc"


### PR DESCRIPTION
## Summary

works `ci.yml` の unslop job を reusable workflow として切り出し、works (および将来 claude-code) から `uses:` で呼び出せるようにする。

実装は works inline 版をそのまま移植。input は `config` 1 つで textlint config path を上書き可能 (default: `.textlintrc.json`)。`actions/checkout` は shared-config 既存の reusable workflow に揃え v6.0.2 を使用。caller 側で `if: github.event_name == 'pull_request'` を持つ前提。

## Usage

```yaml
jobs:
  unslop:
    if: github.event_name == 'pull_request'
    uses: MH4GF/shared-config/.github/workflows/_unslop.yml@<sha>
```

## Why

works の unslop inline 実装 (約 60 行の bash) を claude-code repo にも入れたい要求があり、コピー&ペースト増殖を避けるため切り出す。

## Verification

- `actionlint .github/workflows/_unslop.yml` clean (local)
- この PR merge 後、works 側で `uses:` (SHA pin) 形へ書き換える PR を別途出し、md/mdx 変更 PR で reusable 経由の実行成否を確認する

## Related

- Linear: https://linear.app/mh4gf/issue/MH-28/shared-config-に-reusable-unslop-workflow-を切り出し-works-を呼び出し側へ切り替える
- works (caller 側) の inline 実装: https://github.com/MH4GF/works/blob/main/.github/workflows/ci.yml
