### PR TITLE
feat: add ignore-paths input to _unslop.yml

### DIFF
--- a/.github/workflows/_unslop.yml
+++ b/.github/workflows/_unslop.yml
@@ -14,6 +14,13 @@ on:
         description: textlint config path (relative to the caller repo root)
         type: string
         default: .textlintrc.json
+      ignore-paths:
+        description: |
+          Newline-separated glob patterns to exclude from unslop.
+          `*` matches a single path segment; `**` matches across `/`.
+          Example: `wiki/raw/**` excludes every file under `wiki/raw/`.
+        type: string
+        default: ""
 
 jobs:
   unslop:
@@ -45,6 +52,7 @@ jobs:
         id: changed
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          IGNORE_PATHS: ${{ inputs.ignore-paths }}
         run: |
           set -euo pipefail
           files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD -- '*.md' '*.mdx' || true)
@@ -52,6 +60,39 @@ jobs:
             echo "No changed Markdown files."
             echo "files=" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+          if [ -n "$IGNORE_PATHS" ]; then
+            files=$(printf '%s\n' "$files" | awk '
+              BEGIN {
+                patterns = ENVIRON["IGNORE_PATHS"]
+                n = split(patterns, pats, "\n")
+                m = 0
+                for (i = 1; i <= n; i++) {
+                  p = pats[i]
+                  if (p == "") continue
+                  gsub(/[.+(){}|^$]/, "\\\\&", p)
+                  gsub(/\*\*/, "@@D@@", p)
+                  gsub(/\*/, "[^/]*", p)
+                  gsub(/@@D@@/, ".*", p)
+                  gsub(/\?/, "[^/]", p)
+                  regexps[++m] = "^" p "$"
+                }
+              }
+              {
+                for (i = 1; i <= m; i++) {
+                  if ($0 ~ regexps[i]) {
+                    print "Ignored by ignore-paths: " $0 > "/dev/stderr"
+                    next
+                  }
+                }
+                print
+              }
+            ')
+            if [ -z "$files" ]; then
+              echo "All changed Markdown files matched ignore-paths."
+              echo "files=" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
           ja_files=""
           while IFS= read -r file; do


### PR DESCRIPTION
Closes MH-31

## Summary

`_unslop.yml` reusable workflow へ `ignore-paths` input を追加する。caller 側で指定した glob パターンと一致する変更ファイルを、unslop 実行前に除外できる。

works repo の `wiki/raw/**` 配下は ingest した元記事の不変ソースで、textlint 違反があっても改変できない。今後 ingest 全件で CI が fail し続けるため、shared-config 側に除外機構を入れる。

## Changes

`.github/workflows/_unslop.yml`

- `workflow_call.inputs` に `ignore-paths` (multiline string, default `""`) を追加
- "Collect changed Markdown files" ステップに awk ベースのフィルターを挿入
- glob → 正規表現変換: `*` は単一セグメント、`**` は `/` 越え、`?` は単一文字
- 全件マッチで除外された場合は `files=""` を出力し、後続の `Run unslop` ステップが スキップ される

caller 側で `with:` を省略した場合は従来挙動を維持（default 空文字）。

## Matching semantics

| Pattern | Matches |
|---|---|
| `wiki/raw/**` | `wiki/raw/a.md`, `wiki/raw/articles/b.md`, `wiki/raw/x/y/z.md` |
| `wiki/raw/*` | `wiki/raw/a.md` のみ（サブディレクトリ不可） |
| `**/_archive/**` | `notes/_archive/old.md`, `wiki/_archive/concepts/x.md` |
| `*.tmp.md` | `draft.tmp.md`（top-level のみ） |

awk 内で glob を `^...$` の正規表現にエスケープ。`*` → `[^/]*`、`**` → `.*`。

## Verification

- `actionlint .github/workflows/_unslop.yml` clean
- ローカルで filter ロジックを実行し、`wiki/raw/**` 指定時に `wiki/raw/articles/foo.md` と `wiki/raw/index.md` が除外、他は通過することを確認
- 複数パターン (`wiki/raw/**` + `**/_archive/**` + `*.tmp.md`) でも正しく除外されることを確認
- `ignore-paths` 未指定時は既存挙動を維持

caller 側 (`MH4GF/works`) の `ci.yml` 更新は本 PR の merge 後に別 PR で実施。

---

https://linear.app/mh4gf/issue/MH-31/shared-config-の-unslop-reusable-workflow-に-ignore-paths-input-を追加し
