### PR TITLE
ci: switch unslop install to gh release download

### DIFF
--- a/.github/workflows/_unslop.yml
+++ b/.github/workflows/_unslop.yml
@@ -31,22 +31,43 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Resolve unslop revision
-        id: unslop-rev
+      - name: Resolve unslop release tag
+        id: unslop-rel
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          sha=$(git ls-remote https://github.com/MH4GF/unslop HEAD | cut -f1)
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          tag=$(gh release view --repo MH4GF/unslop --json tagName --jq .tagName)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Cache unslop binary
         id: cache-unslop
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: ~/.cargo/bin/unslop
-          key: unslop-${{ runner.os }}-${{ steps.unslop-rev.outputs.sha }}
+          path: ~/.local/bin/unslop
+          key: unslop-${{ runner.os }}-${{ steps.unslop-rel.outputs.tag }}
 
-      - name: Install unslop
+      - name: Download unslop binary
         if: steps.cache-unslop.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/MH4GF/unslop --rev ${{ steps.unslop-rev.outputs.sha }} --locked
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UNSLOP_TAG: ${{ steps.unslop-rel.outputs.tag }}
+        run: |
+          set -euo pipefail
+          archive=unslop-x86_64-unknown-linux-gnu.tar.gz
+          tmpdir=$(mktemp -d)
+          gh release download "$UNSLOP_TAG" \
+            --repo MH4GF/unslop \
+            --pattern "$archive" \
+            --pattern "${archive}.sha256" \
+            --dir "$tmpdir"
+          (cd "$tmpdir" && shasum -a 256 -c "${archive}.sha256")
+          mkdir -p "$HOME/.local/bin"
+          tar -xzf "$tmpdir/$archive" -C "$HOME/.local/bin" unslop
+          chmod +x "$HOME/.local/bin/unslop"
+
+      - name: Add unslop to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Collect changed Markdown files
         id: changed


### PR DESCRIPTION
Closes MH-34

## 概要

`_unslop.yml` reusable workflow の unslop 取得を `cargo install --git` から `gh release download` ベースへ置き換える。lindera + IPADIC を含む release ビルドは cache miss 時の所要が 1 分超だった。prebuilt binary の DL ならば ~10 秒程度まで短縮できる。前提として、MH-33 が unslop 側へ追加した release workflow が `unslop-x86_64-unknown-linux-gnu.tar.gz` を main push 毎にアップロードしている。

## 変更点

- `gh release view --repo MH4GF/unslop` で latest tag を解決
- `actions/cache` の key を `unslop-<os>-<release-tag>` に変更 (同 tag 内は cache hit)
- cache miss 時のみ `gh release download` でアーカイブ + sha256 を取得、`shasum -a 256 -c` で検証、`~/.local/bin/unslop` へ展開
- `~/.local/bin` を `$GITHUB_PATH` に追加 (cache hit / miss 両方で実行)
- `ignore-paths` / 日本語 (ひらがな・カタカナ・漢字) フィルタ / per-file 実行 / exit code 集約は維持

## 設計判断

- 取得対象は `gh release view` で resolve した最新 tag。現行 cargo install (`git ls-remote HEAD`) と同じ「常に最新を引く」semantic を維持する
- release tag は date-based (`v2026.06.18.144309` 形式) で main push 毎に発行される。caller PR の連続実行内では同 tag が引かれるため cache が効く
- DL リトライは最小 (なし)。release 配布が失敗する状況は別 issue で扱う
- archive の sha256 検証は安全策として残す。release artifact が同梱しているので追加コストはない

## E2E 検証

shared-config 単体の self CI は `_actionlint.yml` のみ。`_unslop.yml` は workflow_call から外部 caller として呼ばれる。本 PR の end-to-end 検証は merge 後、works repo の `ci.yml` SHA pin を更新する後続 PR が担う。

local:

```bash
actionlint .github/workflows/_unslop.yml
# exit 0
```

works PR 側で確認する内容:

- unslop job が `gh release download` 経由で成功する
- cache miss 時の job 所要時間が 30 秒以内
- md/mdx 変更ファイルが正しく抽出され per-file 実行される
- 日本語フィルタが効く

## スコープ外

- 既存 caller の cargo install fallback 維持 (release DL に一本化)
- multi-arch (x86_64-linux-gnu 1 target のみ。Actions runner が arm64 になるまで不要)
- works / claude-code 側 ci.yml の SHA pin 更新 (本 merge 後に出す別 PR)

https://linear.app/mh4gf/issue/MH-34/shared-config-の-reusable-unslop-workflow-を-release-binary-dl
