### PR TITLE
ci(_unslop): install unslop via gh release download

### DIFF
--- a/.github/workflows/_unslop.yml
+++ b/.github/workflows/_unslop.yml
@@ -31,22 +31,41 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Resolve unslop revision
+      - name: Resolve unslop release tag
         id: unslop-rev
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          sha=$(git ls-remote https://github.com/MH4GF/unslop HEAD | cut -f1)
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          tag=$(gh release view --repo MH4GF/unslop --json tagName --jq .tagName)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Cache unslop binary
         id: cache-unslop
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: ~/.cargo/bin/unslop
-          key: unslop-${{ runner.os }}-${{ steps.unslop-rev.outputs.sha }}
+          path: ~/.local/bin/unslop
+          key: unslop-${{ runner.os }}-${{ steps.unslop-rev.outputs.tag }}
 
       - name: Install unslop
         if: steps.cache-unslop.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/MH4GF/unslop --rev ${{ steps.unslop-rev.outputs.sha }} --locked
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.unslop-rev.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          tmp=$(mktemp -d)
+          gh release download "$TAG" --repo MH4GF/unslop \
+            --pattern 'unslop-x86_64-unknown-linux-gnu.tar.gz' \
+            --pattern 'unslop-x86_64-unknown-linux-gnu.tar.gz.sha256' \
+            --dir "$tmp"
+          (cd "$tmp" && sha256sum -c unslop-x86_64-unknown-linux-gnu.tar.gz.sha256)
+          tar -xzf "$tmp/unslop-x86_64-unknown-linux-gnu.tar.gz" -C "$tmp"
+          install -m 755 "$tmp/unslop" "$HOME/.local/bin/unslop"
+
+      - name: Add unslop to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Collect changed Markdown files
         id: changed


### PR DESCRIPTION
## Summary

unslop binary の install を `cargo install` から `gh release download` (`MH4GF/unslop` の latest release) へ切り替える。
binary は事前ビルド済みのため install 時間を ~10 秒程度に短縮できる。
cache miss 時の reusable workflow 全体の所要時間が 30 秒以内に収まる見込み。

works / claude-code の unslop CI から本 reusable workflow を呼ぶときの待ち時間と Actions minutes 消費を削減する。

## Changes

`.github/workflows/_unslop.yml`:

- `Resolve unslop revision` step を `Resolve unslop release tag` に変更する。
  `git ls-remote ... HEAD` で main HEAD SHA を取る代わりに、
  `gh release view --repo MH4GF/unslop --json tagName` で最新 release tag を取る。
- cache path を `~/.cargo/bin/unslop` から `~/.local/bin/unslop` に変更する。
  cache key の suffix を SHA から release tag に変更する。
- `Install unslop` step を `cargo install --git ...` から `gh release download` ベースに置き換える。
  `--pattern 'unslop-x86_64-unknown-linux-gnu.tar.gz'` と `.sha256` を DL し、
  `sha256sum -c` で検証、`tar -xzf` 展開、`install -m 755` で `~/.local/bin/unslop` に配置する。
- `Add unslop to PATH` step を追加し `$HOME/.local/bin` を `$GITHUB_PATH` に登録する。
  ubuntu-latest runner で `~/.local/bin` がデフォルト PATH にある保証はないため明示する。

unslop は main push 毎に date-based tag (`v2026.06.18.144309` 形式) を切って release する。
`gh release view --repo MH4GF/unslop` から常に最新版を取得すれば、従来の HEAD SHA pin と semantic 等価。

ignore-paths / 日本語 markdown filter / per-file `unslop` 実行 / violation で exit non-zero の挙動はすべて据え置き。

## Validation

- [x] `actionlint .github/workflows/_unslop.yml` ローカル green
- [ ] shared-config workflows-ci.yml の actionlint job green (PR push 後)
- [ ] works repo 側で本 reusable workflow を呼ぶ PR を出して unslop job 所要時間が 30 秒以内であることを確認する。
  本 PR merge 後、別 PR として実施する。

## Notes

- DL 対象 release は `gh release view --repo MH4GF/unslop --json tagName` で取得する最新 release を使う。
  main push 毎 release のため pin しなくても semantic は cargo install ベースと等価。
- sha256 verify は release asset の `.sha256` ファイルが `<hash>  <filename>` 形式 (sha256sum -c 互換) であることをローカル DL で確認済み。
- actions/cache は維持する。同一 release tag 内で 2 回目以降の job は ~5 秒短縮できる。
  release tag 変更時 (main push 毎) は cache miss となり DL 経由で install する。

## Linear

Part of [MH-34](https://linear.app/mh4gf/issue/MH-34/shared-config-の-reusable-unslop-workflow-を-release-binary-dl).

本 PR merge 後、works repo の `.github/workflows/ci.yml` の `uses:` SHA pin を新 merge SHA へ更新する PR を別途出す。
issue の最終 close はその works PR 側で行う。
