### PR TITLE
fix(_unslop): disable core.quotePath so non-ASCII md paths reach per-file run

### DIFF
--- a/.github/workflows/_unslop.yml
+++ b/.github/workflows/_unslop.yml
@@ -76,7 +76,7 @@ jobs:
           IGNORE_PATHS: ${{ inputs.ignore-paths }}
         run: |
           set -euo pipefail
-          files=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD -- '*.md' '*.mdx' || true)
+          files=$(git -c core.quotePath=false diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD -- '*.md' '*.mdx' || true)
           if [ -z "$files" ]; then
             echo "No changed Markdown files."
             echo "files=" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes MH-43

## Outcome

`.github/workflows/_unslop.yml` の `Collect changed Markdown files` step を修正する。
これにより、非 ASCII を含む md/mdx を per-file 実行へ確実に渡せるようになる。
対象は日本語・空白・括弧など、quote されると壊れるすべてのパス。

## Root cause

GitHub Actions runner 上の git は `core.quotePath` を `true` のまま使う。
そのため `git diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD -- '*.md' '*.mdx'` の出力は壊れる。
具体的には非 ASCII パスを `"..."` で quote する。
バイト列も octal escape として出力する。
後段の `while IFS= read -r file; do [ -r "$file" ] || continue;` ループは literal `"..."` を本物のパスと扱えず、当該ファイルをスキップする。
結果 step log は `No Japanese Markdown files changed.` になる。
works PR #196（run id `27741123977`）で発覚した。

## Fix

`git -c core.quotePath=false diff --name-only ...` に切り替える。
`-c` は本コマンドだけに効く override のため、runner や caller repo の git config を書き換えない。

## Local reproduction

works repo の PR #196（`327ca3fe...17959a1f`）を materialize し、修正前後の collect step を bash で実行した。

```text
================= BUG REPRODUCTION (CI default) (core.quotePath=true) =================
--- raw git diff output ---
"scraps/open/unslop CI \343\202\222 release binary DL \343\201\270\345\210\207\343\202\212\346\233\277\343\201\210 (MH-34).md"
--- end raw ---
candidate: "scraps/open/unslop CI \343\202\222 release binary DL \343\201\270\345\210\207\343\202\212\346\233\277\343\201\210 (MH-34).md" (readable=NO)
--- ja_files ---
--- end ja_files ---

================= FIX (quotePath=false) (core.quotePath=false) =================
--- raw git diff output ---
scraps/open/unslop CI を release binary DL へ切り替え (MH-34).md
--- end raw ---
candidate: scraps/open/unslop CI を release binary DL へ切り替え (MH-34).md (readable=yes)
--- ja_files ---
scraps/open/unslop CI を release binary DL へ切り替え (MH-34).md
--- end ja_files ---
```

要点は次のとおり。

```bash
git -c core.quotePath=true  diff --name-only --diff-filter=ACMR \
  327ca3fe...17959a1f -- '*.md' '*.mdx'   # quote される (バグ再現)
git -c core.quotePath=false diff --name-only --diff-filter=ACMR \
  327ca3fe...17959a1f -- '*.md' '*.mdx'   # raw パス が出る (fix)
```

`-c core.quotePath=true` は runner の既定値を明示再現する目的で使った。
本 PR の fix では `false` を hard-code する。

## CI 上の検証

shared-config 自身は `_unslop.yml` を dogfood していない。
本 PR 単体では runner 上の per-file 実行を観測できない。
そのため完了条件 2（works 側で日本語名 md を 1 件追加した検証 PR の log 確認）は follow-up issue に切り出した。
本 PR の change は caller workflow の最小 fix だけに絞る。

## スコープ

- `.github/workflows/_unslop.yml` の `git diff` 行に `-c core.quotePath=false` を 1 箇所だけ挿入

## スコープ 外

- shared-config に dogfood job を追加すること（textlint config 整備が必要で別議論）
- unslop binary 側の挙動変更
- works / claude-code 個別 ci.yml の調整

## Linear

https://linear.app/mh4gf/issue/MH-43/shared-config-unslopyml-が非-ascii-名-md-を-per-file-実行から漏らす-bug
