### PR TITLE
feat(unslop): works / claude-code 共通の prh.yml を single source として追加

### DIFF
--- a/.github/workflows/_unslop.yml
+++ b/.github/workflows/_unslop.yml
@@ -31,6 +31,17 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Fetch shared prh.yml
+        run: |
+          set -euo pipefail
+          if [ -f prh.yml ]; then
+            echo "repo-local prh.yml があるため shared 版の取得をスキップ"
+            exit 0
+          fi
+          curl -fsSL --retry 3 \
+            https://raw.githubusercontent.com/MH4GF/shared-config/main/unslop/prh.yml \
+            -o prh.yml
+
       - name: Resolve unslop release tag
         id: unslop-rel
         env:

--- a/.github/workflows/unslop-config-ci.yml
+++ b/.github/workflows/unslop-config-ci.yml
@@ -1,0 +1,85 @@
+name: Unslop Config CI
+
+on:
+  push:
+    paths:
+      - unslop/**
+      - .github/workflows/unslop-config-ci.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-prh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve unslop release tag
+        id: unslop-rel
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag=$(gh release view --repo MH4GF/unslop --json tagName --jq .tagName)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Cache unslop binary
+        id: cache-unslop
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.local/bin/unslop
+          key: unslop-${{ runner.os }}-${{ steps.unslop-rel.outputs.tag }}
+
+      - name: Download unslop binary
+        if: steps.cache-unslop.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UNSLOP_TAG: ${{ steps.unslop-rel.outputs.tag }}
+        run: |
+          set -euo pipefail
+          archive=unslop-x86_64-unknown-linux-gnu.tar.gz
+          tmpdir=$(mktemp -d)
+          gh release download "$UNSLOP_TAG" \
+            --repo MH4GF/unslop \
+            --pattern "$archive" \
+            --pattern "${archive}.sha256" \
+            --dir "$tmpdir"
+          (cd "$tmpdir" && shasum -a 256 -c "${archive}.sha256")
+          mkdir -p "$HOME/.local/bin"
+          tar -xzf "$tmpdir/$archive" -C "$HOME/.local/bin" unslop
+          chmod +x "$HOME/.local/bin/unslop"
+
+      - name: Add unslop to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # unslop は rule file の load 失敗を警告のみで素通りするため、
+      # 「違反 fixture が検出される = rule が load できている」を正とする
+      - name: Smoke test prh.yml
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/textlintrc.json" <<EOF
+          {
+            "rules": {
+              "prh": {
+                "rulePaths": ["$GITHUB_WORKSPACE/unslop/prh.yml"]
+              }
+            }
+          }
+          EOF
+
+          printf 'これは tx をリソースとして消費するテストです。\n' > "$RUNNER_TEMP/violation.md"
+          if unslop -c "$RUNNER_TEMP/textlintrc.json" --no-color "$RUNNER_TEMP/violation.md" > "$RUNNER_TEMP/out.txt" 2>&1; then
+            echo "::error::violation fixture が検出されなかった。prh.yml が load できていない可能性がある"
+            cat "$RUNNER_TEMP/out.txt"
+            exit 1
+          fi
+          if grep -q "failed to load prh" "$RUNNER_TEMP/out.txt"; then
+            echo "::error::prh.yml の load に失敗した"
+            cat "$RUNNER_TEMP/out.txt"
+            exit 1
+          fi
+
+          printf 'これはトランザクションのテストです。\n' > "$RUNNER_TEMP/clean.md"
+          unslop -c "$RUNNER_TEMP/textlintrc.json" --no-color "$RUNNER_TEMP/clean.md"

--- a/unslop/prh.yml
+++ b/unslop/prh.yml
@@ -1,0 +1,92 @@
+# unslop (prh) の共通 rule 定義。MH4GF/works と MH4GF/claude-code の両方から使う。
+#
+# 利用側:
+# - CI: _unslop.yml (reusable workflow) が caller repo に repo-local prh.yml が
+#   ない場合、この file を raw URL で取得して使う
+# - ローカル (unslop-guard hook): raw URL から TTL 付きで cache して使う
+version: 1
+
+rules:
+  # 名詞
+  - expected: トランザクション
+    pattern: /\btx\b/i
+  - expected: コネクション
+    pattern: /\bconn\b/i
+  - expected: リトライ
+    pattern: /\bretry\b/i
+  - expected: ワーカー
+    pattern: /\bworker\b/i
+  - expected: トリガー
+    pattern: /\btrigger\b/i
+  - expected: 指摘事項
+    pattern: /\bfindings\b/i
+  - expected: レビュアー
+    pattern: /\breviewer\b/i
+  - expected: カスタム
+    pattern: /\bcustom\b/i
+  - expected: ツール
+    pattern: /\btool\b/i
+  - expected: アクセス
+    pattern: /\baccess\b/i
+  - expected: トークン
+    pattern: /\btoken\b/i
+  - expected: スコープ
+    pattern: /\bscope\b/i
+  - expected: セクション
+    pattern: /§/
+  - expected: オンボーディング
+    pattern: /\bonboarding\b/i
+  - expected: 秘匿情報
+    pattern: /\bcredentials?\b/i
+  - expected: フラグ
+    pattern: /\bflags?\b/i
+  - expected: レポート
+    pattern: /\breport\b/i
+  - expected: 種類 / 構成 / 派生形
+    pattern: /\bvariants?\b/i
+
+  # 動詞
+  - expected: スキップ
+    pattern: /\bskip\b/i
+  - expected: ディスパッチ
+    pattern: /\bdispatch\b/i
+  - expected: デプロイ
+    pattern: /\bdeploy\b/i
+  - expected: コミット
+    pattern: /\bcommit\b/i
+  - expected: なりすます
+    pattern: /\bimpersonate\b/i
+  - expected: 読む / 使う / 利用する / 参照する 等
+    pattern: /消費(?=する|され|させ|し[てた])/
+  - expected: 除去
+    pattern: /\bevict\b/i
+
+  # 形容詞・副詞
+  - expected: 一律
+    pattern: /\bblanket\b/i
+  - expected: 妥当
+    pattern: /\blegitimate\b/i
+  - expected: 情報通知のみ
+    pattern: /\binformational only\b/i
+  - expected: 冪等
+    pattern: /\bidempotent\b/i
+  - expected: 実行中
+    pattern: /\bin-flight\b/i
+
+  # 比喩・造語
+  - expected: デッドロックで中断された側
+    pattern: /\bdeadlock victim\b/i
+  - expected: 掃き出し処理
+    pattern: /\bmop-up\b/i
+  - expected: 外側のループ
+    pattern: /\bouter loop\b/i
+
+  # 経緯ラベル (docs / コメントから削除する。履歴は git で追える)
+  - expected: コメントから削除する (履歴は git で追える)
+    pattern: /経緯[:：]/
+  - expected: コメントから削除する (履歴は git で追える)
+    pattern: /廃止理由[:：]/
+  - expected: コメントから削除する (履歴は git で追える)
+    pattern: /旧仕様[:：]/
+  - expected: コメントから削除する (履歴は git で追える)
+    pattern: /\bWhy removed\b/i

--- a/unslop/prh.yml
+++ b/unslop/prh.yml
@@ -1,9 +1,4 @@
-# unslop (prh) の共通 rule 定義。MH4GF/works と MH4GF/claude-code の両方から使う。
-#
-# 利用側:
-# - CI: _unslop.yml (reusable workflow) が caller repo に repo-local prh.yml が
-#   ない場合、この file を raw URL で取得して使う
-# - ローカル (unslop-guard hook): raw URL から TTL 付きで cache して使う
+# unslop (prh) の共通 rule 定義
 version: 1
 
 rules:


### PR DESCRIPTION
## 概要

MH4GF/works と MH4GF/claude-code に並存していた prh.yml (unslop の rule 定義) を、この repo の `unslop/prh.yml` に single source として統合する。

Linear: [MH-155](https://linear.app/mh4gf/issue/MH-155/ハーネス改善-works-claude-code-の-prhyml-を統合管理する仕組み検討)

## 変更内容

- **`unslop/prh.yml`**: 両 repo の rule をマージした共通定義。reconcile 内容は次のとおり
  - 表記違い同義 rule 4 件を統一: `§` は文字リテラル、`credentials?` / `flags?` に正規化、`消費` は lookahead 版 (works 版) を採用
  - works のみにあった経緯ラベル 4 rule (MH-141 由来) と claude-code のみにあった 5 rule (レポート / variant / evict / 冪等 / in-flight) を統合
- **`_unslop.yml`**: caller repo の checkout に repo-local `prh.yml` がない場合、この repo の raw URL から取得する step を追加。repo-local file があればそちらを優先 (escape hatch)
- **`unslop-config-ci.yml`**: prh.yml の smoke test。unslop は rule file の load 失敗を警告のみで素通りするため、「違反 fixture が検出される = load 成功」を検証する

## 検証

ローカルの unslop (release build) で smoke test 相当を実行済み:

- 違反 fixture (`tx` / `消費する` / `経緯:` / `variant`) → 4 件検出、rc=1
- clean fixture (`トランザクション`) → rc=0

## Follow-up (別 PR)

- works: prh.yml 削除 + `_unslop.yml` の pin をこの変更を含む sha へ bump
- claude-code: 同上 + unslop-guard hook を raw URL cache 方式へ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
